### PR TITLE
Delete by query

### DIFF
--- a/lib/ex_typesense.ex
+++ b/lib/ex_typesense.ex
@@ -100,6 +100,9 @@ defmodule ExTypesense do
   defdelegate delete_document_by_id(conn \\ Connection.new(), collection_name, document_id),
     to: ExTypesense.Document
 
+  defdelegate delete_documents_by_query(conn \\ Connection.new(), collection_name, query), to: ExTypesense.Document
+
+
   defdelegate update_document(conn \\ Connection.new(), document), to: ExTypesense.Document
   defdelegate upsert_document(conn \\ Connection.new(), document), to: ExTypesense.Document
 

--- a/lib/ex_typesense/document.ex
+++ b/lib/ex_typesense/document.ex
@@ -519,14 +519,8 @@ defmodule ExTypesense.Document do
   def delete_documents_by_query(conn \\ Connection.new(), collection_name, query)
 
   def delete_documents_by_query(conn, collection_name, %{filter_by: filter_by} = query)
-      when not is_nil(filter_by) and is_binary(filter_by) and is_atom(collection_name) do
+      when not is_nil(filter_by) and is_binary(filter_by) and (is_atom(collection_name) or is_binary(collection_name)) do
     collection_name = collection_name.__schema__(:source)
-    path = Path.join([@collections_path, collection_name, @documents_path])
-    HttpClient.request(conn, %{method: :delete, path: path, query: query})
-  end
-
-  def delete_documents_by_query(conn, collection_name, %{filter_by: filter_by} = query)
-      when not is_nil(filter_by) and is_binary(filter_by) and is_binary(collection_name) do
     path = Path.join([@collections_path, collection_name, @documents_path])
     HttpClient.request(conn, %{method: :delete, path: path, query: query})
   end


### PR DESCRIPTION
Basically I've replicated the methods in the main repo for delete documents by query. In the main repo the defdelegate for delete_documents_by_query isn't really referencing the right method in the document.ex file so I guess is an issue. 

Why I haven't use the original repo?, basically because some methods have changed their interface.